### PR TITLE
propagate shasta exit code up through wrapper.py

### DIFF
--- a/aarch64/wrapper.py
+++ b/aarch64/wrapper.py
@@ -125,11 +125,11 @@ def main(argv):
     print("\nRunning Shasta assembly. You can follow along by running `tail -f shasta_assembly.log` in the output directory.\n...\n", flush=True)
     shastaLogFile = open('shasta_assembly.log', 'w')
     shastaCmdArr = [shastaBinary] + shastaArgs
-    subprocess.run(
+    shastaReturncode = subprocess.run(
         shastaCmdArr,
         stdout=shastaLogFile,
         stderr=subprocess.STDOUT
-    )
+    ).returncode
     shastaLogFile.close()
     
     shastaAssemblyDirectory = "ShastaRun"
@@ -140,8 +140,8 @@ def main(argv):
     subprocess.run(['cp', 'shasta_assembly.log', shastaAssemblyDirectory])
 
     print("\n\nDone. Check the assembly directory for results.", flush=True)
-    return
+    return shastaReturncode
 
 
 if __name__ == '__main__':
-    main(sys.argv[1:])    
+    sys.exit(main(sys.argv[1:]))

--- a/x86_64/wrapper.py
+++ b/x86_64/wrapper.py
@@ -130,11 +130,11 @@ def main(argv):
     print("\nRunning Shasta assembly. You can follow along by running `tail -f shasta_assembly.log` in the output directory.\n...\n", flush=True)
     shastaLogFile = open('shasta_assembly.log', 'w')
     shastaCmdArr = [shastaBinary] + shastaArgs
-    subprocess.run(
+    shastaReturncode = subprocess.run(
         shastaCmdArr,
         stdout=shastaLogFile,
         stderr=subprocess.STDOUT
-    )
+    ).returncode
     shastaLogFile.close()
     
     shastaAssemblyDirectory = "ShastaRun"
@@ -145,8 +145,8 @@ def main(argv):
     subprocess.run(['cp', 'shasta_assembly.log', shastaAssemblyDirectory])
 
     print("\n\nDone. Check the assembly directory for results.", flush=True)
-    return
+    return shastaReturncode
 
 
 if __name__ == '__main__':
-    main(sys.argv[1:])    
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
The current docker container `wrapper.py` always returns with a 0 exit code.  This prevents invoking scripts/workflows from determining the exit status of the shasta assembler.

This PR changes the wrapper.py to return the exit code which is returned by the underlying Shasta subprocess.

In other words, if you invoke wrapper.py in a way that causes Shasta to exit non-zero, the wrapper will propagate that up, allowing the docker user to further utilize the non-zero exit code.
