### PR TITLE
add support for running released images not cached in the docker image

### DIFF
--- a/HowToBuildNewImage.md
+++ b/HowToBuildNewImage.md
@@ -1,25 +1,27 @@
-New Docker images need to be created after every Shasta release. 
+New Docker images need to be created after every Shasta release.
 
 ### Setup
+
 1. Install Docker on the machine that will be used for building these docker images. Detailed instructions available at https://docs.docker.com/engine/install/
 
 2. [Optional, but recommended] Set up Docker to be managed as a non-root user by following instructions at https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user. If you do this step, you won't need to prefix docker commands with `sudo`.
 
 3. Create a Github personal access token using instructions at https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token. The personal access token must have necessary permissions granted to it, specificially `delete:packages`, `write:packages`, `repo` & `workflow`. The token also needs to be authorized for accessing `chanzuckerberg` org in Github.
 
-4. Ensure that you have `Write` permission granted at https://github.com/orgs/chanzuckerberg/packages/container/shasta/settings 
+4. Ensure that you have `Write` permission granted at https://github.com/orgs/chanzuckerberg/packages/container/shasta/settings
 
 ### Prepare to create new images
+
 1. Clone the repository by running `git clone https://github.com/chanzuckerberg/shasta-docker`
 
-2. Edit `shasta-docker/x86_64/wrapper.py` & `shasta-docker/aarch64/wrapper.py` to add the new Shasta release version number (at two places in each file).
+2. Edit `shasta-docker/x86_64/Makefile` & `shasta-docker/aarch64/Makefile` to bump the `shasta_version` to the next integer. This is the docker image/package version and is unrelated to the Shasta version.
 
-3. Edit `shasta-docker/x86_64/Makefile` & `shasta-docker/aarch64/Makefile` to bump the `shasta_version` to the next integer. This is the docker image/package version and is unrelated to the Shasta version.
-
-4. Commit the changes and push them upstream.
+3. Commit the changes and push them upstream.
 
 ### How to create a x86_64 image?
+
 The following needs to be done on an x86_64 machine.
+
 1. Log in ghcr.io by running `echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_USERNAME --password-stdin`
 2. Run `git clone https://github.com/chanzuckerberg/shasta-docker && cd shasta-docker/x86_64`
 3. Build a new Docker image by running `make build`
@@ -28,7 +30,9 @@ The following needs to be done on an x86_64 machine.
 6. Verify that the new image shows up on https://github.com/orgs/chanzuckerberg/packages/container/package/shasta
 
 ### How to create an arm64v8 image?
+
 The following needs to be done on an arm64v8 machine. E.g. Graviton2 ec2 instances.
+
 1. Log in ghcr.io by running `echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_USERNAME --password-stdin`
 2. Run `git clone https://github.com/chanzuckerberg/shasta-docker && cd shasta-docker/aarch64`
 3. Build a new Docker image by running `make build`
@@ -36,8 +40,8 @@ The following needs to be done on an arm64v8 machine. E.g. Graviton2 ec2 instanc
 5. Publish the new Docker image by running `make push`
 6. Verify that the new image shows up on https://github.com/orgs/chanzuckerberg/packages/container/package/shasta-arm64v8
 
-
 ### Commands to cleanup local Docker state on your ec2 instance (while building an image)
+
 Docker keeps around intermediate layers/images and if your machine doesn't have enough memory, you might run into issues. You can blow away these cached layers/images by running the following commands.
 
 ```

--- a/aarch64/Dockerfile
+++ b/aarch64/Dockerfile
@@ -1,5 +1,6 @@
 FROM arm64v8/ubuntu:20.04
-MAINTAINER Bhal Agashe, bagashe@chanzuckerberg.com
+LABEL org.opencontainers.image.authors="bruce@chanzuckerberg.com"
+LABEL org.opencontainers.image.source https://github.com/chanzuckerberg/shasta-docker
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=US/Los_Angeles

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -1,5 +1,5 @@
 image_name = chanzuckerberg/shasta-arm64v8
-shasta_version = 6
+shasta_version = 7
 tag = ${shasta_version}
 
 # Steps

--- a/aarch64/wrapper.py
+++ b/aarch64/wrapper.py
@@ -2,8 +2,13 @@
 
 import sys
 import os
+import os.path
 import subprocess
 import time
+import re
+
+# Platform specific binary name prefix
+shastaBinaryPrefix = "shasta-Linux-ARM-"
 
 helpMessage = """
 Usage:
@@ -11,7 +16,8 @@ Usage:
         -v `pwd`:/output \\
         <DOCKER-IMAGE> \\
         <SHASTA-VERSION-STRING> \\
-        --input input.fasta
+        --input input.fasta \\
+        --config <CONFIG>
 
     OR
 
@@ -19,130 +25,210 @@ Usage:
         -v `pwd`:/output \\
         <DOCKER-IMAGE> \\
         <SHASTA-VERSION-STRING> \\
-        --input input.fasta --memoryMode filesystem --memoryBacking 2M
+        --input input.fasta \\
+        --config <CONFIG> \\
+        --memoryMode filesystem --memoryBacking 2M
 
     Accepted values for SHASTA-VERSION-STRING are:
-        0.9.0         : Shasta release 0.9.0
-        0.8.0         : Shasta release 0.8.0
-        0.7.0         : Shasta release 0.7.0
-        0.6.0         : Shasta release 0.6.0
+        <RELEASE-TAG> : This will run a specified release, eg, 0.9.0.
         latest-commit : This will download and build the current main branch of chanzuckerberg/shasta
         <COMMIT-HASH> : This will download and build the main branch of chanzuckerberg/shasta at the given commit
-    
+
+    The available Shasta releases can be found at https://github.com/chanzuckerberg/shasta/releases.
+    This image contains cached executables for the following <RELEASE-TAG> values:
+{}
+
+Shasta documentation can be found at https://chanzuckerberg.github.io/shasta/
 """
 
+
 def usage():
-    print(helpMessage, flush=True)
+    tags = sorted(
+        [tag for tag in get_locally_available_releases().keys()],
+        key=lambda t: tuple(map(int, (t.split(".")))),
+        reverse=True,
+    )
+    msg = "       {:<14s} : Shasta release {:s}"
+    available_versions = "\n".join([msg.format(tag, tag) for tag in tags])
+    print(helpMessage.format(available_versions), flush=True)
     return
+
 
 def clone():
     try:
-        subprocess.check_call(['git', 'clone', 'https://github.com/chanzuckerberg/shasta.git'])
+        subprocess.check_call(
+            ["git", "clone", "https://github.com/chanzuckerberg/shasta.git"]
+        )
     except subprocess.CalledProcessError as err:
         print(err, flush=True)
         sys.exit(2)
-    
+
 
 def pullLatest():
     try:
-        subprocess.check_call(['git', 'pull', '--rebase'])
+        subprocess.check_call(["git", "pull", "--rebase"])
     except subprocess.CalledProcessError:
-        print('"git pull --rebase" command failed. Docker needs Internet access.', flush=True)
-        sys.exit(2)  
-    
+        print(
+            '"git pull --rebase" command failed. Docker needs Internet access.',
+            flush=True,
+        )
+        sys.exit(2)
+
 
 def getValidCommitHash(commitHash):
-    if commitHash == 'latest-commit':
-        return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').rstrip()
-        
+    if commitHash == "latest-commit":
+        return (
+            subprocess.check_output(["git", "rev-parse", "HEAD"])
+            .decode("utf-8")
+            .rstrip()
+        )
+
     try:
-        subprocess.check_call(['git', 'cat-file', '-t', commitHash])
+        subprocess.check_call(["git", "cat-file", "-t", commitHash])
     except subprocess.CalledProcessError:
-        print('{} is not a valid git commit hash.'.format(commitHash, flush=True))
+        print(f"{commitHash} is not a valid git commit hash.", flush=True)
         usage()
         sys.exit(2)
     return commitHash
 
 
 def releaseTagIsValid(releaseTag):
-    # Shasta uses semantic versioning.
-    return 2 == releaseTag.count('.')
+    # Shasta uses semantic versioning. Weak test for something that looks like a semver.
+    return re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", releaseTag) is not None
+
+
+def build(shastaVersion):
+    cwd = os.getcwd()
+
+    # shastaVersion could be a commit-hash or 'latest-commit'
+    print("Downloading and building Shasta code at the requested commit.", flush=True)
+    os.chdir("/tmp")
+    clone()
+    os.chdir("/tmp/shasta")
+
+    pullLatest()
+
+    shastaVersion = getValidCommitHash(shastaVersion)
+    print(f"Building Shasta at commit - {shastaVersion}")
+
+    subprocess.run(["git", "checkout", shastaVersion], check=True)
+
+    subprocess.run(["mkdir", "-p", "/tmp/shasta-build"])
+    os.chdir("/tmp/shasta-build")
+
+    print("Configuring & Building Shasta ...", flush=True)
+    subprocess.run(
+        [
+            "cmake",
+            "../shasta",
+            "-DBUILD_DYNAMIC_LIBRARY=OFF",
+            "-DBUILD_DYNAMIC_EXECUTABLE=OFF",
+            "-DBUILD_WITH_HTTP_SERVER=OFF",
+        ],
+        check=True,
+    )
+
+    subprocess.run(["make", "install/strip", "-j"], check=True)
+
+    print("Done building Shasta", flush=True)
+
+    shastaBinary = "/tmp/shasta-build/shasta-install/bin/shasta"
+
+    # Go back to the original working directory.
+    os.chdir(cwd)
+
+    return shastaBinary
+
+
+def get_locally_available_releases():
+    """Return the Shasta releases available in this image."""
+    install_dir = "/opt/"
+    binary_prefix = f"/opt/{shastaBinaryPrefix}"
+    shasta_executables = [
+        full_path
+        for p in os.listdir(install_dir)
+        if (full_path := os.path.join(install_dir, p))
+        and p.startswith(shastaBinaryPrefix)
+        and os.path.isfile(full_path)
+        and os.access(full_path, os.X_OK)
+    ]
+    # { tag_name: full_path }
+    return {
+        full_path[len(binary_prefix) :]: full_path for full_path in shasta_executables
+    }
+
+
+def download_gh_release(tag_name):
+    """
+    Attempt to download the given release tag.  Return None if the tag_name is not a release.
+    Return the binary file location if successful.
+    """
+    shastaBinary = f"/tmp/{shastaBinaryPrefix}{tag_name}"
+    downloadURL = f"https://github.com/chanzuckerberg/shasta/releases/download/{tag_name}/{shastaBinaryPrefix}{tag_name}"
+    try:
+        res = subprocess.run(
+            ["curl", "--fail", "--silent", "-L", "--output", shastaBinary, downloadURL]
+        )
+        if res.returncode == 0:
+            return shastaBinary
+        if res.returncode == 22:
+            # curl indicating a HTTP response 400 or above, ie, typically means the tag is not a release.
+            return None
+        # otherwise, an unexpected error
+        res.check_returncode()
+    except subprocess.CalledProcessError as err:
+        print(err, flush=True)
+        sys.exit(2)
 
 
 def main(argv):
-    if 'help' in argv or '--help' in argv:
+    if len(argv) == 0 or "help" in argv or "--help" in argv:
         usage()
         sys.exit(1)
 
-    availableShastaReleases = ['0.9.0', '0.8.0', '0.7.0', '0.6.0']
     shastaVersion = argv[0]
     shastaArgs = argv[1:]
-    
-    print("Shasta Version : {}".format(shastaVersion), flush=True)
-    shastaBinary = "/opt/shasta-Linux-ARM-{}".format(shastaVersion)
-    
-    if shastaVersion not in availableShastaReleases:
+
+    print(f"Shasta Version : {shastaVersion}", flush=True)
+
+    local_releases = get_locally_available_releases()
+    if shastaVersion in local_releases:
+        shastaBinary = local_releases[shastaVersion]
+    elif not (shastaBinary := download_gh_release(shastaVersion)):
         if releaseTagIsValid(shastaVersion):
             # Unavailable release tag was specified. shastaVersion is not latest-commit or a valid commit hash.
-            print("Shasta version {} is not available on this platform. Run the command with `--help` to see available options.".format(shastaVersion))
+            print(
+                f"Shasta version {shastaVersion} is not available on this platform. Run the command with `--help` to see available options."
+            )
             sys.exit(2)
-
-        cwd = os.getcwd()
-
-        # shastaVersion could be a commit-hash or 'latest-commit'
-        print("Downloading and building Shasta code at the requested commit.", flush=True)
-        os.chdir('/tmp')
-        clone()
-        os.chdir('/tmp/shasta')
-        
-        pullLatest()
-
-        shastaVersion = getValidCommitHash(shastaVersion)
-        print('Building Shasta at commit - {}'.format(shastaVersion))
-        
-        subprocess.check_call(['git', 'checkout', shastaVersion])
-    
-        subprocess.run(['mkdir', '-p', '/tmp/shasta-build'])
-        os.chdir('/tmp/shasta-build')
-        
-        print('Configuring & Building Shasta ...', flush=True)
-        cmakeCmd = subprocess.run(
-            ['cmake', '../shasta', '-DBUILD_DYNAMIC_LIBRARY=OFF', '-DBUILD_DYNAMIC_EXECUTABLE=OFF', '-DBUILD_WITH_HTTP_SERVER=OFF'],
-        )
-        
-        makeCmd = subprocess.run(['make', 'install/strip', '-j'])
-        
-        print('Done building Shasta', flush=True)
-
-        shastaBinary = "/tmp/shasta-build/shasta-install/bin/shasta"
-        
-        # Go back to the original working directory.
-        os.chdir(cwd)
+        # Otherwise, attempt to build it
+        shastaBinary = build(shastaVersion)
 
     time.sleep(2)
 
     # Run the right version of Shasta.
-    print("\n\nUsing {} Shasta executable.".format(shastaBinary), flush=True)
-    print("\nRunning Shasta assembly. You can follow along by running `tail -f shasta_assembly.log` in the output directory.\n...\n", flush=True)
-    shastaLogFile = open('shasta_assembly.log', 'w')
+    print(f"\n\nUsing {shastaBinary} Shasta executable.", flush=True)
+    print(
+        "\nRunning Shasta assembly. You can follow along by running `tail -f shasta_assembly.log` in the output directory.\n...\n",
+        flush=True,
+    )
+    shastaLogFile = open("shasta_assembly.log", "w")
     shastaCmdArr = [shastaBinary] + shastaArgs
     shastaReturncode = subprocess.run(
-        shastaCmdArr,
-        stdout=shastaLogFile,
-        stderr=subprocess.STDOUT
+        shastaCmdArr, stdout=shastaLogFile, stderr=subprocess.STDOUT
     ).returncode
     shastaLogFile.close()
-    
+
     shastaAssemblyDirectory = "ShastaRun"
     if "--assemblyDirectory" in shastaArgs:
         idx = shastaArgs.index("--assemblyDirectory")
         shastaAssemblyDirectory = shastaArgs[idx + 1]
 
-    subprocess.run(['cp', 'shasta_assembly.log', shastaAssemblyDirectory])
+    subprocess.run(["cp", "shasta_assembly.log", shastaAssemblyDirectory])
 
     print("\n\nDone. Check the assembly directory for results.", flush=True)
     return shastaReturncode
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main(sys.argv[1:]))

--- a/x86_64/Dockerfile
+++ b/x86_64/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04
-MAINTAINER Bhal Agashe, bagashe@chanzuckerberg.com
+LABEL org.opencontainers.image.authors="bruce@chanzuckerberg.com"
+LABEL org.opencontainers.image.source https://github.com/chanzuckerberg/shasta-docker
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=US/Los_Angeles

--- a/x86_64/Makefile
+++ b/x86_64/Makefile
@@ -1,5 +1,5 @@
 image_name = chanzuckerberg/shasta
-shasta_version = 6
+shasta_version = 7
 tag = ${shasta_version}
 
 # Steps

--- a/x86_64/wrapper.py
+++ b/x86_64/wrapper.py
@@ -2,8 +2,13 @@
 
 import sys
 import os
+import os.path
 import subprocess
 import time
+import re
+
+# Platform specific binary name prefix
+shastaBinaryPrefix = "shasta-Linux-"
 
 helpMessage = """
 Usage:
@@ -11,7 +16,8 @@ Usage:
         -v `pwd`:/output \\
         <DOCKER-IMAGE> \\
         <SHASTA-VERSION-STRING> \\
-        --input input.fasta
+        --input input.fasta \\
+        --config <CONFIG>
 
     OR
 
@@ -19,135 +25,210 @@ Usage:
         -v `pwd`:/output \\
         <DOCKER-IMAGE> \\
         <SHASTA-VERSION-STRING> \\
-        --input input.fasta --memoryMode filesystem --memoryBacking 2M
+        --input input.fasta \\
+        --config <CONFIG> \\
+        --memoryMode filesystem --memoryBacking 2M
 
     Accepted values for SHASTA-VERSION-STRING are:
-        0.9.0         : Shasta release 0.9.0
-        0.8.0         : Shasta release 0.8.0
-        0.7.0         : Shasta release 0.7.0
-        0.6.0         : Shasta release 0.6.0
-        0.5.1         : Shasta release 0.5.1
-        0.5.0         : Shasta release 0.5.0
-        0.4.0         : Shasta release 0.4.0
-        0.3.0         : Shasta release 0.3.0
-        0.2.0         : Shasta release 0.2.0
-        0.1.0         : Shasta release 0.1.0
+        <RELEASE-TAG> : This will run a specified release, eg, 0.9.0.
         latest-commit : This will download and build the current main branch of chanzuckerberg/shasta
         <COMMIT-HASH> : This will download and build the main branch of chanzuckerberg/shasta at the given commit
-    
+
+    The available Shasta releases can be found at https://github.com/chanzuckerberg/shasta/releases.
+    This image contains cached executables for the following <RELEASE-TAG> values:
+{}
+
+Shasta documentation can be found at https://chanzuckerberg.github.io/shasta/
 """
 
+
 def usage():
-    print(helpMessage, flush=True)
+    tags = sorted(
+        [tag for tag in get_locally_available_releases().keys()],
+        key=lambda t: tuple(map(int, (t.split(".")))),
+        reverse=True,
+    )
+    msg = "       {:<14s} : Shasta release {:s}"
+    available_versions = "\n".join([msg.format(tag, tag) for tag in tags])
+    print(helpMessage.format(available_versions), flush=True)
     return
+
 
 def clone():
     try:
-        subprocess.check_call(['git', 'clone', 'https://github.com/chanzuckerberg/shasta.git'])
+        subprocess.check_call(
+            ["git", "clone", "https://github.com/chanzuckerberg/shasta.git"]
+        )
     except subprocess.CalledProcessError as err:
         print(err, flush=True)
         sys.exit(2)
-    
+
 
 def pullLatest():
     try:
-        subprocess.check_call(['git', 'pull', '--rebase'])
+        subprocess.check_call(["git", "pull", "--rebase"])
     except subprocess.CalledProcessError:
-        print('"git pull --rebase" command failed. Docker needs Internet access.', flush=True)
-        sys.exit(2)  
-    
+        print(
+            '"git pull --rebase" command failed. Docker needs Internet access.',
+            flush=True,
+        )
+        sys.exit(2)
+
 
 def getValidCommitHash(commitHash):
-    if commitHash == 'latest-commit':
-        return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').rstrip()
-        
+    if commitHash == "latest-commit":
+        return (
+            subprocess.check_output(["git", "rev-parse", "HEAD"])
+            .decode("utf-8")
+            .rstrip()
+        )
+
     try:
-        subprocess.check_call(['git', 'cat-file', '-t', commitHash])
+        subprocess.check_call(["git", "cat-file", "-t", commitHash])
     except subprocess.CalledProcessError:
-        print('{} is not a valid git commit hash.'.format(commitHash, flush=True))
+        print(f"{commitHash} is not a valid git commit hash.", flush=True)
         usage()
         sys.exit(2)
     return commitHash
 
 
 def releaseTagIsValid(releaseTag):
-    # Shasta uses semantic versioning.
-    return 2 == releaseTag.count('.')
+    # Shasta uses semantic versioning. Weak test for something that looks like a semver.
+    return re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", releaseTag) is not None
+
+
+def build(shastaVersion):
+    cwd = os.getcwd()
+
+    # shastaVersion could be a commit-hash or 'latest-commit'
+    print("Downloading and building Shasta code at the requested commit.", flush=True)
+    os.chdir("/tmp")
+    clone()
+    os.chdir("/tmp/shasta")
+
+    pullLatest()
+
+    shastaVersion = getValidCommitHash(shastaVersion)
+    print(f"Building Shasta at commit - {shastaVersion}")
+
+    subprocess.run(["git", "checkout", shastaVersion], check=True)
+
+    subprocess.run(["mkdir", "-p", "/tmp/shasta-build"])
+    os.chdir("/tmp/shasta-build")
+
+    print("Configuring & Building Shasta ...", flush=True)
+    subprocess.run(
+        [
+            "cmake",
+            "../shasta",
+            "-DBUILD_DYNAMIC_LIBRARY=OFF",
+            "-DBUILD_DYNAMIC_EXECUTABLE=OFF",
+            "-DBUILD_WITH_HTTP_SERVER=OFF",
+        ],
+        check=True,
+    )
+
+    subprocess.run(["make", "install/strip", "-j"], check=True)
+
+    print("Done building Shasta", flush=True)
+
+    shastaBinary = "/tmp/shasta-build/shasta-install/bin/shasta"
+
+    # Go back to the original working directory.
+    os.chdir(cwd)
+
+    return shastaBinary
+
+
+def get_locally_available_releases():
+    """Return the Shasta releases available in this image."""
+    install_dir = "/opt/"
+    binary_prefix = f"/opt/{shastaBinaryPrefix}"
+    shasta_executables = [
+        full_path
+        for p in os.listdir(install_dir)
+        if (full_path := os.path.join(install_dir, p))
+        and p.startswith(shastaBinaryPrefix)
+        and os.path.isfile(full_path)
+        and os.access(full_path, os.X_OK)
+    ]
+    # { tag_name: full_path }
+    return {
+        full_path[len(binary_prefix) :]: full_path for full_path in shasta_executables
+    }
+
+
+def download_gh_release(tag_name):
+    """
+    Attempt to download the given release tag.  Return None if the tag_name is not a release.
+    Return the binary file location if successful.
+    """
+    shastaBinary = f"/tmp/{shastaBinaryPrefix}{tag_name}"
+    downloadURL = f"https://github.com/chanzuckerberg/shasta/releases/download/{tag_name}/{shastaBinaryPrefix}{tag_name}"
+    try:
+        res = subprocess.run(
+            ["curl", "--fail", "--silent", "-L", "--output", shastaBinary, downloadURL]
+        )
+        if res.returncode == 0:
+            return shastaBinary
+        if res.returncode == 22:
+            # curl indicating a HTTP response 400 or above, ie, typically means the tag is not a release.
+            return None
+        # otherwise, an unexpected error
+        res.check_returncode()
+    except subprocess.CalledProcessError as err:
+        print(err, flush=True)
+        sys.exit(2)
 
 
 def main(argv):
-    if 'help' in argv or '--help' in argv:
+    if len(argv) == 0 or "help" in argv or "--help" in argv:
         usage()
         sys.exit(1)
 
-    availableShastaReleases = ['0.9.0', '0.8.0', '0.7.0', '0.6.0', '0.5.1', '0.5.0', '0.4.0', '0.3.0', '0.2.0', '0.1.0']
     shastaVersion = argv[0]
     shastaArgs = argv[1:]
-    
-    print("Shasta Version : {}".format(shastaVersion), flush=True)
-    shastaBinary = "/opt/shasta-Linux-{}".format(shastaVersion)
-    
-    if shastaVersion not in availableShastaReleases:
+
+    print(f"Shasta Version : {shastaVersion}", flush=True)
+
+    local_releases = get_locally_available_releases()
+    if shastaVersion in local_releases:
+        shastaBinary = local_releases[shastaVersion]
+    elif not (shastaBinary := download_gh_release(shastaVersion)):
         if releaseTagIsValid(shastaVersion):
             # Unavailable release tag was specified. shastaVersion is not latest-commit or a valid commit hash.
-            print("Shasta version {} is not available on this platform. Run the command with `--help` to see available options.".format(shastaVersion))
+            print(
+                f"Shasta version {shastaVersion} is not available on this platform. Run the command with `--help` to see available options."
+            )
             sys.exit(2)
-        cwd = os.getcwd()
-
-        # shastaVersion could be a commit-hash or 'latest-commit'
-        print("Downloading and building Shasta code at the requested commit.", flush=True)
-        os.chdir('/tmp')
-        clone()
-        os.chdir('/tmp/shasta')
-        
-        pullLatest()
-
-        shastaVersion = getValidCommitHash(shastaVersion)
-        print('Building Shasta at commit - {}'.format(shastaVersion))
-        
-        subprocess.check_call(['git', 'checkout', shastaVersion])
-    
-        subprocess.run(['mkdir', '-p', '/tmp/shasta-build'])
-        os.chdir('/tmp/shasta-build')
-        
-        print('Configuring & Building Shasta ...', flush=True)
-        cmakeCmd = subprocess.run(
-            ['cmake', '../shasta', '-DBUILD_DYNAMIC_LIBRARY=OFF', '-DBUILD_DYNAMIC_EXECUTABLE=OFF', '-DBUILD_WITH_HTTP_SERVER=OFF'],
-        )
-        
-        makeCmd = subprocess.run(['make', 'install/strip', '-j'])
-        
-        print('Done building Shasta', flush=True)
-
-        shastaBinary = "/tmp/shasta-build/shasta-install/bin/shasta"
-        
-        # Go back to the original working directory.
-        os.chdir(cwd)
+        # Otherwise, attempt to build it
+        shastaBinary = build(shastaVersion)
 
     time.sleep(2)
 
     # Run the right version of Shasta.
-    print("\n\nUsing {} Shasta executable.".format(shastaBinary), flush=True)
-    print("\nRunning Shasta assembly. You can follow along by running `tail -f shasta_assembly.log` in the output directory.\n...\n", flush=True)
-    shastaLogFile = open('shasta_assembly.log', 'w')
+    print(f"\n\nUsing {shastaBinary} Shasta executable.", flush=True)
+    print(
+        "\nRunning Shasta assembly. You can follow along by running `tail -f shasta_assembly.log` in the output directory.\n...\n",
+        flush=True,
+    )
+    shastaLogFile = open("shasta_assembly.log", "w")
     shastaCmdArr = [shastaBinary] + shastaArgs
     shastaReturncode = subprocess.run(
-        shastaCmdArr,
-        stdout=shastaLogFile,
-        stderr=subprocess.STDOUT
+        shastaCmdArr, stdout=shastaLogFile, stderr=subprocess.STDOUT
     ).returncode
     shastaLogFile.close()
-    
+
     shastaAssemblyDirectory = "ShastaRun"
     if "--assemblyDirectory" in shastaArgs:
         idx = shastaArgs.index("--assemblyDirectory")
         shastaAssemblyDirectory = shastaArgs[idx + 1]
 
-    subprocess.run(['cp', 'shasta_assembly.log', shastaAssemblyDirectory])
+    subprocess.run(["cp", "shasta_assembly.log", shastaAssemblyDirectory])
 
     print("\n\nDone. Check the assembly directory for results.", flush=True)
     return shastaReturncode
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Changes,primary to the wrapper.py script:
* If the specified Shasta version looks like semver, and is not cached in the docker image, attempt to download it from the GH repo.  This change allows the release of new Shasta pre-built binaries without requiring an immediate docker image update.
* The wrapper script will now  automatically generate the list of Shasta versions cached in the image, rather than requiring a manual code update.  This simplifies maintenance when the image is rebuilt.
* minor code style cleanup
