### PR TITLE
Add github action to build docker container for shasta 

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -2,8 +2,6 @@ name: buildx
 
 on:
   push:
-    branches:
-    - test-gha # to be deleted after test
     tags:
     - "*"
   schedule:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           ref: ${{ env.GITHUB_REF_NAME }}
           repository: chanzuckerberg/shasta
+          path: shasta
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push image
-        run: docker buildx build --push \
-             --tag ghcr.io/chanzuckerberg/shasta:{SHASTA_VERSION:-latest} \
-             --platform linux/amd64,linux/arm64 \
-             .
+        run: |
+          docker buildx build
+          --push
+          --tag ghcr.io/chanzuckerberg/shasta:{SHASTA_VERSION:-latest}
+          --platform linux/amd64,linux/arm64
+          .

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -3,10 +3,11 @@ name: buildx
 on:
   push:
     branches:
-    - main
-    - test-gha
+    - test-gha # to be deleted after test
     tags:
     - "*"
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   buildx:
@@ -14,16 +15,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      #- name: Login to GitHub Container Registry
-      #  uses: docker/login-action@v2
-      #  with:
-      #    registry: ghcr.io
-      #    username: ${{ github.actor }}
-      #    password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout shasta source code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.GITHUB_REF_NAME }}
+          repository: chanzuckerberg/shasta
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up version for releases
+        if: ${{ github.ref_name != 'main' }}
+        run: echo SHASTA_VERSION=${GITHUB_REF_NAME} >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push image
-        run: |
-          docker buildx build --platform linux/amd64,linux/arm64 .
+        run: docker buildx build --push \
+             --tag ghcr.io/chanzuckerberg/shasta:{SHASTA_VERSION:-latest} \
+             --platform linux/amd64,linux/arm64 \
+             .

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,0 +1,29 @@
+name: buildx
+
+on:
+  push:
+    branches:
+    - main
+    - test-gha
+    tags:
+    - "*"
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      #- name: Login to GitHub Container Registry
+      #  uses: docker/login-action@v2
+      #  with:
+      #    registry: ghcr.io
+      #    username: ${{ github.actor }}
+      #    password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push image
+        run: |
+          docker buildx build --platform linux/amd64,linux/arm64 .

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push image
-        run: |
-          docker buildx build \
-          --push \
-          --tag ghcr.io/chanzuckerberg/shasta:{SHASTA_VERSION:-latest} \
-          --platform linux/amd64,linux/arm64 \
+        run: >
+          docker buildx build
+          --push
+          --tag ghcr.io/chanzuckerberg/shasta:{SHASTA_VERSION:-latest}
+          --platform linux/amd64,linux/arm64
           .

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -37,6 +37,6 @@ jobs:
         run: >
           docker buildx build
           --push
-          --tag ghcr.io/chanzuckerberg/shasta:{SHASTA_VERSION:-latest}
+          --tag ghcr.io/chanzuckerberg/shasta:${SHASTA_VERSION:-latest}
           --platform linux/amd64,linux/arm64
           .

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -35,8 +35,8 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Build and push image
         run: |
-          docker buildx build
-          --push
-          --tag ghcr.io/chanzuckerberg/shasta:{SHASTA_VERSION:-latest}
-          --platform linux/amd64,linux/arm64
+          docker buildx build \
+          --push \
+          --tag ghcr.io/chanzuckerberg/shasta:{SHASTA_VERSION:-latest} \
+          --platform linux/amd64,linux/arm64 \
           .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:22.04
+LABEL org.opencontainers.image.authors="bruce@chanzuckerberg.com"
+LABEL org.opencontainers.image.source https://github.com/chanzuckerberg/shasta-docker
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=US/Los_Angeles
+
+# Build shasta release
+ARG BUILD_ID
+WORKDIR /opt
+
+RUN apt-get update && apt install -y git
+RUN git clone https://github.com/chanzuckerberg/shasta.git
+WORKDIR /opt/shasta
+RUN if [[ -z "${SHASTA_VERSION}" ]]; then \
+      git checkout tags/${BUILD_ID} -b ${BUILD_ID} \
+      BUILD_ID="Shasta Release ${SHASTA_VERSION}" ; \
+    else \
+      BUILD_ID="Shasta Nightly" ; \
+    fi
+RUN /opt/shasta/scripts/InstallPrerequisites-Ubuntu.sh
+RUN mkdir shasta-build
+WORKDIR /opt/shasta-build
+RUN cmake ../shasta -DBUILD_ID=${BUILD_ID} && \
+    make -j 2 all && \
+    make install/strip && \
+    mv shasta-install /opt/shasta-Ubuntu-22.04
+RUN rm -rf /opt/shasta /opt/shasta-build
+
+WORKDIR /opt/shasta-Ubuntu-22.04
+ENTRYPOINT ["/opt/shasta-Ubuntu-22.04/bin/shasta"]
+


### PR DESCRIPTION
* Workflow can be triggered with tagging or scheduled cron job for nightly
* build arm64/amd64 images upon trigger and push to ghcr

if we are comfortable with the build we can potentially delete other build flow and update build doc

and to my very surprise, the amd64 build flow is much slower than arm64, not the other way around!